### PR TITLE
Optimized split_le_base and le_sum

### DIFF
--- a/src/gadgets.rs
+++ b/src/gadgets.rs
@@ -1,18 +1,25 @@
 use plonky2::{
     field::{extension::Extendable},
     hash::hash_types::RichField,
-    iop::target::{BoolTarget, Target},
-    plonk::{
-        circuit_builder::CircuitBuilder,
+    iop::{
+        target::{BoolTarget, Target}
     },
+    plonk::{
+        circuit_builder::CircuitBuilder
+    },
+    util::{
+        log_floor
+    }
 };
 
 // Assuming U32Target is defined somewhere like this:
 // pub struct U32Target(pub Target);
 
-use crate::gates::{ChGate, MajGate};
+use crate::gates::{ChGate, MajGate, BaseSumGateOptimized, BaseSplitGeneratorOptimized};
 // Re-export the gate for convenience
 use crate::gates::{Xor3Gate};
+use core::borrow::Borrow;
+use itertools::Itertools;
 
 pub trait XorOps<F: RichField + Extendable<D>, const D: usize> {
     fn add_xor3(
@@ -33,6 +40,14 @@ pub trait XorOps<F: RichField + Extendable<D>, const D: usize> {
         b: BoolTarget,
         c: BoolTarget,
     ) -> BoolTarget;
+    fn le_sum_optimized(
+        &mut self, 
+        bits: impl Iterator<Item = impl Borrow<BoolTarget>>
+    ) -> Target;
+    fn split_le_base_optimized<const B: usize>(
+        &mut self, x: Target, 
+        num_limbs: usize
+    ) -> Vec<Target>;
 }
 
 impl<F: RichField + Extendable<D>, const D: usize> XorOps<F, D> for CircuitBuilder<F, D> {
@@ -89,5 +104,55 @@ impl<F: RichField + Extendable<D>, const D: usize> XorOps<F, D> for CircuitBuild
         self.connect(b.target, wire_b);
         self.connect(c.target, wire_c);
         BoolTarget::new_unsafe(Target::wire(gate, 3 + op_ind * 4))
+    }
+
+    /// Takes an iterator of bits `(b_i)` and returns `sum b_i * 2^i`, i.e.,
+    /// the number with little-endian bit representation given by `bits`.
+
+    fn le_sum_optimized(&mut self, bits: impl Iterator<Item = impl Borrow<BoolTarget>>) -> Target {
+        let bits = bits.map(|b| *b.borrow()).collect_vec();
+        let num_bits = bits.len();
+        assert!(
+            num_bits <= log_floor(F::ORDER, 2),
+            "{} bits may overflow the field",
+            num_bits
+        );
+        if num_bits == 0 {
+            return self.zero();
+        }
+
+        debug_assert!(
+            BaseSumGateOptimized::<2>::START_LIMBS + num_bits <= self.config.num_routed_wires,
+            "Not enough routed wires."
+        );
+        let gate_type = BaseSumGateOptimized::<2>::new_from_config(&self.config, num_bits + 2);
+        let constants = vec![];
+        let (row, i) = self.find_slot(gate_type, &constants, &constants);
+        let offset = i * (gate_type.num_limbs + 1);
+        for (limb, wire) in bits
+            .iter()
+            .zip(BaseSumGateOptimized::<2>::START_LIMBS + offset..BaseSumGateOptimized::<2>::START_LIMBS + num_bits + offset)
+        {
+            self.connect(limb.target, Target::wire(row, wire));
+        }
+        for l in (BaseSumGateOptimized::<2>::START_LIMBS + offset..BaseSumGateOptimized::<2>::START_LIMBS+gate_type.num_limbs + offset).skip(num_bits) {
+            self.assert_zero(Target::wire(row, l));
+        }
+        Target::wire(row, BaseSumGateOptimized::<2>::WIRE_SUM + offset)
+    }
+
+    fn split_le_base_optimized<const B: usize>(&mut self, x: Target, num_limbs: usize) -> Vec<Target> {
+        let gate_type = BaseSumGateOptimized::<B>::new_from_config(&self.config, num_limbs);
+        let constants = vec![];
+        let (row, i) = self.find_slot(gate_type, &constants, &constants);
+        let offset = i * (gate_type.num_limbs + 1);
+        let sum = Target::wire(row, BaseSumGateOptimized::<B>::WIRE_SUM + offset);
+        self.connect(x, sum);
+        self.add_simple_generator(BaseSplitGeneratorOptimized::<B>{
+            row: row,
+            i : i, 
+            num_limbs: gate_type.num_limbs
+        });
+        Target::wires_from_range(row, gate_type.limbs(i))
     }
 }

--- a/src/gadgets.rs
+++ b/src/gadgets.rs
@@ -12,79 +12,82 @@ use plonky2::{
 
 use crate::gates::{ChGate, MajGate};
 // Re-export the gate for convenience
-pub use crate::gates::Xor3Gate;
+use crate::gates::{Xor3Gate};
 
 pub trait XorOps<F: RichField + Extendable<D>, const D: usize> {
     fn add_xor3(
         &mut self,
-        a: Vec<BoolTarget>,
-        b: Vec<BoolTarget>,
-        c: Vec<BoolTarget>,
-    ) -> Vec<BoolTarget>;
+        a: BoolTarget,
+        b: BoolTarget,
+        c: BoolTarget
+    ) -> BoolTarget;
     fn add_maj(
         &mut self,
-        a: Vec<BoolTarget>,
-        b: Vec<BoolTarget>,
-        c: Vec<BoolTarget>,
-    ) -> Vec<BoolTarget>;
+        a: BoolTarget,
+        b: BoolTarget,
+        c: BoolTarget,
+    ) -> BoolTarget;
     fn add_ch(
         &mut self,
-        a: Vec<BoolTarget>,
-        b: Vec<BoolTarget>,
-        c: Vec<BoolTarget>,
-    ) -> Vec<BoolTarget>;
+        a: BoolTarget,
+        b: BoolTarget,
+        c: BoolTarget,
+    ) -> BoolTarget;
 }
 
 impl<F: RichField + Extendable<D>, const D: usize> XorOps<F, D> for CircuitBuilder<F, D> {
     fn add_xor3(
         &mut self,
-        a: Vec<BoolTarget>,
-        b: Vec<BoolTarget>,
-        c: Vec<BoolTarget>,
-    ) -> Vec<BoolTarget> {
-        let gate = Xor3Gate::<F, D>::new_from_config(&self.config);
-        let row = self.add_gate(gate, vec![]);
-        let mut res = Vec::new();
-        for i in 0..16 {
-            self.connect(a[i].target, Target::wire(row, 0 + i * 4));
-            self.connect(b[i].target, Target::wire(row, 1 + i * 4));
-            self.connect(c[i].target, Target::wire(row, 2 + i * 4));
-            res.push(BoolTarget::new_unsafe(Target::wire(row, 3 + i * 4)));
-        }
-        res
+        a: BoolTarget,
+        b: BoolTarget,
+        c: BoolTarget
+    ) -> BoolTarget {
+        let gate = Xor3Gate::new_from_config(&self.config);
+        let constants = vec![];
+        let (gate, i) = self.find_slot(gate, &constants, &constants);
+        let op_ind = i;
+        let wire_a = Target::wire(gate, 0 + op_ind * 4);
+        let wire_b = Target::wire(gate, 1 + op_ind * 4);
+        let wire_c = Target::wire(gate, 2 + op_ind * 4);
+        self.connect(a.target, wire_a);
+        self.connect(b.target, wire_b);
+        self.connect(c.target, wire_c);
+        BoolTarget::new_unsafe(Target::wire(gate, 3 + op_ind * 4))
     }
     fn add_maj(
         &mut self,
-        a: Vec<BoolTarget>,
-        b: Vec<BoolTarget>,
-        c: Vec<BoolTarget>,
-    ) -> Vec<BoolTarget> {
-        let gate = MajGate::<F, D>::new_from_config(&self.config);
-        let row = self.add_gate(gate, vec![]);
-        let mut res = Vec::new();
-        for i in 0..16 {
-            self.connect(a[i].target, Target::wire(row, 0 + i * 4));
-            self.connect(b[i].target, Target::wire(row, 1 + i * 4));
-            self.connect(c[i].target, Target::wire(row, 2 + i * 4));
-            res.push(BoolTarget::new_unsafe(Target::wire(row, 3 + i * 4)));
-        }
-        res
+        a: BoolTarget,
+        b: BoolTarget,
+        c: BoolTarget,
+    ) -> BoolTarget {
+        let gate = MajGate::new_from_config(&self.config);
+        let constants = vec![];
+        let (gate, i) = self.find_slot(gate, &constants, &constants);
+        let op_ind = i;
+        let wire_a = Target::wire(gate, 0 + op_ind * 4);
+        let wire_b = Target::wire(gate, 1 + op_ind * 4);
+        let wire_c = Target::wire(gate, 2 + op_ind * 4);
+        self.connect(a.target, wire_a);
+        self.connect(b.target, wire_b);
+        self.connect(c.target, wire_c);
+        BoolTarget::new_unsafe(Target::wire(gate, 3 + op_ind * 4))
     }
     fn add_ch(
         &mut self,
-        a: Vec<BoolTarget>,
-        b: Vec<BoolTarget>,
-        c: Vec<BoolTarget>,
-    ) -> Vec<BoolTarget> {
-        let gate = ChGate::<F, D>::new_from_config(&self.config);
-        let row = self.add_gate(gate, vec![]);
-        let mut res = Vec::new();
-        for i in 0..16 {
-            self.connect(a[i].target, Target::wire(row, 0 + i * 4));
-            self.connect(b[i].target, Target::wire(row, 1 + i * 4));
-            self.connect(c[i].target, Target::wire(row, 2 + i * 4));
-            res.push(BoolTarget::new_unsafe(Target::wire(row, 3 + i * 4)));
-        }
-        res
+        a: BoolTarget,
+        b: BoolTarget,
+        c: BoolTarget,
+    ) -> BoolTarget {
+        let gate = ChGate::new_from_config(&self.config);
+        let constants = vec![];
+        let (gate, i) = self.find_slot(gate, &constants, &constants);
+        let op_ind = i;
+        let wire_a = Target::wire(gate, 0 + op_ind * 4);
+        let wire_b = Target::wire(gate, 1 + op_ind * 4);
+        let wire_c = Target::wire(gate, 2 + op_ind * 4);
+        self.connect(a.target, wire_a);
+        self.connect(b.target, wire_b);
+        self.connect(c.target, wire_c);
+        BoolTarget::new_unsafe(Target::wire(gate, 3 + op_ind * 4))
     }
 }

--- a/src/gates.rs
+++ b/src/gates.rs
@@ -70,7 +70,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Xor3Gate<F, D>
         0
     }
     fn degree(&self) -> usize {
-        2
+        4
     }
     fn num_constraints(&self) -> usize {
         self.num_ops
@@ -88,9 +88,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Xor3Gate<F, D>
             // Direct formula - no intermediate wires needed
             let u = a - b;
             let d = u * u;
-            let v = o - c;
-            let e = v * v;
-            res.push(d - e);
+            let v = d - c;
+            let expected = v * v;
+            res.push(o - expected);
         }
         res
     }
@@ -111,9 +111,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Xor3Gate<F, D>
             // Build the same computation using circuit operations
             let u = builder.sub_extension(a, b); // u = a - b
             let d = builder.mul_extension(u, u); // d = u * u = (a-b)^2
-            let v = builder.sub_extension(o, c); // v = o - c
-            // Return the constraint: v * v - d= 0
-            let constraint = builder.mul_sub_extension(v, v, d);
+            let v = builder.sub_extension(d, c); // v = d - c = (a-b)^2 - c
+            let expected = builder.mul_extension(v, v); // expected = v * v = ((a-b)^2 - c)^2
+
+            // Return the constraint: o - expected = 0
+            let constraint = builder.sub_extension(o, expected);
             res.push(constraint);
         }
         

--- a/src/gates.rs
+++ b/src/gates.rs
@@ -1,22 +1,30 @@
 use anyhow::Result;
 use std::marker::PhantomData;
+use core::ops::Range;
 
 use plonky2::{
-    field::{extension::Extendable, types::Field},
-    gates::gate::{Gate},
+    field::{extension::Extendable, types::{Field}},
+    gates::{
+        gate::{Gate},
+    },
     hash::hash_types::RichField,
     iop::{
         ext_target::ExtensionTarget,
         generator::{GeneratedValues, SimpleGenerator, WitnessGeneratorRef},
-        target::{Target},
+        target::{Target, BoolTarget},
         witness::{PartitionWitness, Witness, WitnessWrite},
     },
     plonk::{
         circuit_builder::CircuitBuilder,
         circuit_data::{CircuitConfig, CommonCircuitData},
-        vars::{EvaluationTargets, EvaluationVars},
+        vars::{
+            EvaluationTargets, EvaluationVars
+        },
+        plonk_common::{reduce_with_powers, reduce_with_powers_ext_circuit}
     },
-    util::serialization::{Buffer, IoResult, Read, Write},
+    util::{
+        serialization::{Buffer, IoResult, Read, Write}
+    }
 };
 
 
@@ -547,5 +555,297 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for ChG
             i,
             _phantom: PhantomData,
         })
+    }
+}
+
+
+
+#[derive(Copy, Clone, Debug)]
+pub struct BaseSumGateOptimized<const B: usize> {
+    pub num_limbs: usize,
+    pub num_ops:usize
+}
+
+
+impl<const B: usize> BaseSumGateOptimized<B> {
+    pub(crate) const fn num_ops(config: &CircuitConfig, num_limbs:usize) -> usize {
+        let wires_per_op = num_limbs + 1;
+        config.num_routed_wires / wires_per_op
+    }
+    
+    pub(crate) fn new(num_limbs: usize, num_ops: usize) -> Self{
+        Self{
+            num_limbs, 
+            num_ops
+        }
+    }
+    pub fn new_from_config(config: &CircuitConfig, num_limbs: usize) -> Self {
+        let num_ops = Self::num_ops(config, num_limbs);
+        Self{
+            num_limbs, 
+            num_ops
+        }
+    }
+
+    pub(crate) const WIRE_SUM: usize = 0;
+    pub(crate) const START_LIMBS: usize = 1;
+
+    /// Returns the index of the `i`th limb wire.
+    pub(crate) const fn limbs(&self, i: usize) -> Range<usize> {
+        let offset = i * (self.num_limbs + 1);
+        Self::START_LIMBS + offset..Self::START_LIMBS + self.num_limbs + offset
+    }
+}
+
+impl<F: RichField + Extendable<D>, const D: usize, const B: usize> Gate<F, D> for BaseSumGateOptimized<B> {
+    fn id(&self) -> String {
+        format!("{self:?} + Base: {B}")
+    }
+
+    fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        dst.write_usize(self.num_limbs)?;
+        dst.write_usize(self.num_ops)
+    }
+
+    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+        let num_limbs = src.read_usize()?;
+        let num_ops = src.read_usize()?;
+        Ok(Self { num_limbs, num_ops })
+    }
+
+    fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {
+        let mut constraints= Vec::new();
+        for i in 0..self.num_ops{
+            let offset: usize = i * (self.num_limbs + 1);
+            let sum = vars.local_wires[Self::WIRE_SUM + offset];
+            let limbs = vars.local_wires[self.limbs(i)].to_vec();
+            let computed_sum = reduce_with_powers(&limbs, F::Extension::from_canonical_usize(B));
+            constraints.push(computed_sum - sum);
+            for limb in limbs {
+                constraints.push(
+                    (0..B)
+                        .map(|i| limb - F::Extension::from_canonical_usize(i))
+                        .product(),
+                );
+            }
+        }
+        
+        constraints
+    }
+
+    fn eval_unfiltered_circuit(
+        &self,
+        builder: &mut CircuitBuilder<F, D>,
+        vars: EvaluationTargets<D>,
+    ) -> Vec<ExtensionTarget<D>> {
+        let base = builder.constant(F::from_canonical_usize(B));
+        let mut constraints = Vec::new();
+        for i in 0..self.num_ops{
+            let offset = i * (self.num_limbs + 1);
+            let sum = vars.local_wires[Self::WIRE_SUM + offset];
+            let limbs = vars.local_wires[self.limbs(i)].to_vec();
+            let computed_sum = reduce_with_powers_ext_circuit(builder, &limbs, base);
+            constraints.push(builder.sub_extension(computed_sum, sum));
+            for limb in limbs {
+                constraints.push({
+                    let mut acc = builder.one_extension();
+                    (0..B).for_each(|i| {
+                        // We update our accumulator as:
+                        // acc' = acc (x - i)
+                        //      = acc x + (-i) acc
+                        // Since -i is constant, we can do this in one arithmetic_extension call.
+                        let neg_i = -F::from_canonical_usize(i);
+                        acc = builder.arithmetic_extension(F::ONE, neg_i, acc, limb, acc)
+                    });
+                    acc
+                });
+            }
+        }   
+        
+        constraints
+    }
+
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<WitnessGeneratorRef<F, D>> {
+        (0..self.num_ops).map(|i| {
+            WitnessGeneratorRef::new(
+                BaseSumGeneratorOptimized::<B> {
+                    row,
+                    i,
+                    num_limbs: self.num_limbs,
+                }.adapter())
+            }).collect()
+    }
+
+    // 1 for the sum then `num_limbs` for the limbs.
+    fn num_wires(&self) -> usize {
+        (1 + self.num_limbs) * self.num_ops
+    }
+
+    fn num_constants(&self) -> usize {
+        0
+    }
+
+    // Bounded by the range-check (x-0)*(x-1)*...*(x-B+1).
+    fn degree(&self) -> usize {
+        B
+    }
+
+    // 1 for checking the sum then `num_limbs` for range-checking the limbs.
+    fn num_constraints(&self) -> usize {
+        (1 + self.num_limbs) * self.num_ops
+    }
+}
+
+
+
+
+
+#[derive(Debug, Default)]
+pub struct BaseSumGeneratorOptimized<const B: usize> {
+    row: usize,
+    i: usize,
+    num_limbs: usize
+}
+
+impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerator<F, D>
+    for BaseSumGeneratorOptimized<B>
+{
+    fn id(&self) -> String {
+        format!("BaseSumGenerator + Base: {B}")
+    }
+
+    fn dependencies(&self) -> Vec<Target> {
+        let offset = self.i * (self.num_limbs + 1);
+        let mut res = Vec::new();
+        for j in 0..self.num_limbs{
+            res.push(Target::wire(self.row, BaseSumGateOptimized::<B>::START_LIMBS + j + offset));
+        }
+        res
+    }
+
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
+        let offset = self.i * (self.num_limbs + 1);
+        let limbs: Vec<BoolTarget> = (0..self.num_limbs).map(|j|{
+            BoolTarget::new_unsafe(Target::wire(self.row, BaseSumGateOptimized::<B>::START_LIMBS + j + offset))
+        }).collect();
+        let sum = limbs
+            .iter()
+            .map(|&t| witness.get_bool_target(t))
+            .rev()
+            .fold(F::ZERO, |acc, limb| {
+                acc * F::from_canonical_usize(B) + F::from_bool(limb)
+            });
+
+        out_buffer.set_target(Target::wire(self.row, BaseSumGateOptimized::<B>::WIRE_SUM + offset), sum)
+    }
+
+    fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        dst.write_usize(self.row)?;
+        dst.write_usize(self.i)?;
+        dst.write_usize(self.num_limbs)
+    }
+
+    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+        let row = src.read_usize()?;
+        let i = src.read_usize()?;
+        let num_limbs = src.read_usize()?;
+        Ok(Self { row, i, num_limbs })
+    }
+}
+
+
+
+
+
+#[derive(Debug, Default)]
+pub struct BaseSplitGeneratorOptimized<const B: usize> {
+    pub row: usize,
+    pub i: usize,
+    pub num_limbs: usize,
+}
+
+impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerator<F, D>
+    for BaseSplitGeneratorOptimized<B>
+{
+    fn id(&self) -> String {
+        format!("BaseSplitGenerator + Base: {B}")
+    }
+
+    fn dependencies(&self) -> Vec<Target> {
+        let offset = self.i * (self.num_limbs + 1);
+        vec![Target::wire(self.row, BaseSumGateOptimized::<B>::WIRE_SUM + offset)]
+    }
+
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
+        let offset = self.i * (self.num_limbs + 1);
+        let sum_value = witness
+            .get_target(Target::wire(self.row, BaseSumGateOptimized::<B>::WIRE_SUM + offset))
+            .to_canonical_u64();
+        debug_assert_eq!(
+            (0..self.num_limbs).fold(sum_value, |acc, _| acc / (B as u64)),
+            0,
+            "Integer too large to fit in given number of limbs"
+        );
+
+        let limbs = (BaseSumGateOptimized::<B>::START_LIMBS + offset..BaseSumGateOptimized::<B>::START_LIMBS + self.num_limbs + offset)
+            .map(|i| Target::wire(self.row, i));
+        let limbs_value = (0..self.num_limbs)
+            .scan(sum_value, |acc, _| {
+                let tmp = *acc % (B as u64);
+                *acc /= B as u64;
+                Some(F::from_canonical_u64(tmp))
+            })
+            .collect::<Vec<_>>();
+
+        for (b, b_value) in limbs.zip(limbs_value) {
+            out_buffer.set_target(b, b_value).expect(&format!("Failed to set target {:?} to {:?}", b, b_value));
+        }
+
+        Ok(())
+    }
+
+    fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        dst.write_usize(self.row)?;
+        dst.write_usize(self.i)?;
+        dst.write_usize(self.num_limbs)
+    }
+
+    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+        let row = src.read_usize()?;
+        let i = src.read_usize()?;
+        let num_limbs = src.read_usize()?;
+        Ok(Self { row, i, num_limbs })
+    }
+    
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use plonky2::field::goldilocks_field::GoldilocksField;
+    use crate::gates::BaseSumGateOptimized;
+    use plonky2::gates::gate_testing::{test_eval_fns, test_low_degree};
+    use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+
+    #[test]
+    fn low_degree() {
+        test_low_degree::<GoldilocksField, _, 4>(BaseSumGateOptimized::<6>::new(11, 5))
+    }
+
+    #[test]
+    fn eval_fns() -> Result<()> {
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+        test_eval_fns::<F, C, _, D>(BaseSumGateOptimized::<6>::new(11, 5))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ pub fn prove_sha256(msg: &[u8]) -> Result<()> {
         "Constructing inner proof with {} gates",
         builder.num_gates()
     );
+    builder.print_gate_counts(0);
     let data = builder.build::<C>();
     let timing = TimingTree::new("prove", Level::Debug);
     let proof = data.prove(pw).unwrap();


### PR DESCRIPTION
le_sum was using a 64-sized BaseSumGate, where 32 were enough. I changed that and also implemented an optimized BaseSumGate that can handle multiple operations per row (2 in this case), which halved the number of gates used collectively by le_sum and split_le_base